### PR TITLE
coordinator - remove accepted and rejected transactions from mempool correctly

### DIFF
--- a/src/blockchain/util.ts
+++ b/src/blockchain/util.ts
@@ -2,7 +2,7 @@ import process from "process";
 import keccak256 from "keccak256";
 import JSONbigint from "json-bigint";
 
-import { WorldState, SignedTransaction, Transaction, ComputeClaim, Staker, Block, TransactionBundle } from "./types";
+import { WorldState, SignedTransaction, Transaction, ComputeClaim, Staker, Block, TransactionBundle, Account } from "./types";
 import { createAccount } from "./transaction";
 import {
   serializeBlock,
@@ -65,6 +65,10 @@ export function stringifyTransaction(txn: Transaction): string {
 
 export function stringifySignedTransaction(txn: SignedTransaction): string {
   return JSONbigint.stringify(txn);
+}
+
+export function stringifyAccount(account: Account): string {
+  return JSONbigint.stringify(account);
 }
 
 export function stringifyStaker(staker: Staker): string {

--- a/src/coordinator/src/node.ts
+++ b/src/coordinator/src/node.ts
@@ -227,8 +227,7 @@ export class CoordinatorNode {
         );
         const daCheckResult = await this.offchainManager.checkTxnBundleDA(txnBundle, blockRandProof, daCommittee);
         for (const txn of daCheckResult.rejectedTxns) {
-          const txnHash = hashSignedTransaction(txn);
-          await this.storage.removePendingTransaction(txnHash);
+          await this.storage.removePendingTransaction(txn);
         }
         if (daCheckResult.acceptedTxns.length == 0) {
           this.log.error(`failed to mint next block - all transactions have failed DA verification`);
@@ -257,6 +256,7 @@ export class CoordinatorNode {
         }
         for (const [txn, err] of rejectedTxns) {
           this.log.info(`transaction ${stringifySignedTransaction(txn)} rejected - ${err.message}`);
+          await this.storage.removePendingTransaction(txn);
         }
 
         // Commit minted block;
@@ -264,8 +264,8 @@ export class CoordinatorNode {
         const rawBlock = serializeBlock(nextBlock);
         await this.claimContract?.submitBlock(rawBlock);
         this.log.info(`block ${blockHash} committed to smart contract`);
+
         await this.storage.commitNextBlock(state, nextBlock);
-        this.log.info(`block ${hashBlock(nextBlock)} committed to local storage`);
       } catch (err: any) {
         this.log.error(`failed to mint next block - ${err.message}`);
       }


### PR DESCRIPTION
1. Coordinator now removes from mepool only rejected transactions and transactions, included into new block (instead of removing all pending transactions in mempool).
2. Update client.sync.test to wait for account nonce instead of waiting for new blocks.